### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Quick start
 ```python
 INSTALLED_APPS = [
     ...
-    'protected_media',
+    'protected_media.apps.ProtectedMediaConfig',
 ]
 ```
 
 2. Include the URLconf in your project urls.py like this::
 ```
-url(r'^protected/', include('protected_media.urls')),
+path('protected/', include('protected_media.urls')),
 ```
 
 3. Add the following settings to `settings.py` if the defaults need to be tweaked:

--- a/example/demo/settings.py
+++ b/example/demo/settings.py
@@ -38,7 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    "protected_media",
+    "protected_media.apps.ProtectedMediaConfig",
     "store"
 ]
 

--- a/example/demo/urls.py
+++ b/example/demo/urls.py
@@ -1,26 +1,26 @@
 """demo URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
+    https://docs.djangoproject.com/en/3.1/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.conf import settings
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r"^protected/", include("protected_media.urls"))
+    path('admin/', admin.site.urls),
+    path("protected/", include("protected_media.urls"))
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Hi @cobusc ,

This PR fixs how we are adding into URLconf. Instead of `django.conf.urls.url()` lets show example with `django.urls.path()` - the new modern way. Also, `url()` will be deprecated in Django 4.0.

Also, let's show adding AppConfig as dotted path as it is recommended at [Django docs](https://docs.djangoproject.com/en/3.1/ref/applications/#configuring-applications). Otherwise we should add `default_app_config` variable inside [\_\_init\_\_.py](https://github.com/cobusc/django-protected-media/blob/master/protected_media/__init__.py) file.