### PR TITLE
Custom permission function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ def SomeModel(models.Model):
     # Files will be stored under PROTECTED_MEDIA_ROOT + upload_to
 ```
 
+6. Define a custom function for permission logic (optional):
+```python
+# settings.py
+PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION = "myapp.utils.custom_permission_function"
+
+# utils.py
+def custom_permission_function(user, path):
+    if user.is_superuser or user.is_staff:
+        return True
+    return False
+```
+
 Overview
 --------
 
@@ -78,7 +90,9 @@ location ^~ /media/ {
 }
 ```
 
-This works well when the media should be publically accessible. However, if the media should be protected, we need a way for Django to check whether the request for the media should only be allowed for logged in (or more stringent criteria) users.
+This works well when the media should be publically accessible. However, if the media should be protected, we need a way
+for Django to check whether the request for the media should only be allowed for logged in (or more stringent criteria)
+users.
 
 The `protected_media` application
 --------------------------------
@@ -86,29 +100,52 @@ The `protected_media` application consists of
 * new `settings.py` attributes,
 * a customized FileSystemStorage class,
 * a custom handler for the protected media URL and
+* a decorator for permission checks
 * additional web server configuration if serving via `nginx` or something similar.
 
-Protected media is stored in a different physical location to publically accessible media. The following settings can be specified in `settings.py`:
+Protected media is stored in a different physical location to publically accessible media. The following settings can be
+specified in `settings.py`:
+
 ```python
 PROTECTED_MEDIA_ROOT = "/some/application/dir/protected/"
 PROTECTED_MEDIA_URL = "/protected"
 PROTECTED_MEDIA_SERVER = "nginx"  # Defaults to "django"
 PROTECTED_MEDIA_LOCATION_PREFIX = "/internal"  # Prefix used in nginx config
+PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION = "myapp.utils.custom_permission_function"  # Optional
 ```
 
 When defining a file or image field that needs to be protected, we use one of the
 classes provided by the `protected_media` application:
+
 * `ProtectedFileField`
 * `ProtectedImageField`
 
 Protected file- and image fields are typically defined as:
+
 ```python
 document = ProtectedFileField(upload_to="uploads/")
 picture = ProtectedImageField(upload_to="uploads/")
 # Files will be stored under PROTECTED_MEDIA_ROOT + upload_to
 ```
 
-These classes have a custom storage backend `ProtectedFileSystemStorage` which mananges the filesystem location and URLs associated with protected media.
+These classes have a custom storage backend `ProtectedFileSystemStorage` which mananges the filesystem location and URLs
+associated with protected media.
+
+Custom permission logic
+--------------------------------
+To enforce business-specific rules for accessing protected media, you can define a custom permission function in your
+settings.py. This function will be dynamically imported and applied after @login_required decorator.
+
+```python
+# settings.py
+PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION = "myapp.utils.custom_permission_function"
+
+# utils.py
+def custom_permission_function(user, path):
+    if user.is_superuser or user.is_staff:
+        return True
+    return False
+```
 
 When `nginx` is used, the configuration must be updated to look like this:
 ```

--- a/protected_media/decorators.py
+++ b/protected_media/decorators.py
@@ -4,6 +4,20 @@ from django.utils.module_loading import import_string
 
 
 def permission_check(permission_func_path):
+    """
+        Decorator to apply permission checks for the view for the file.
+
+        Args:
+            permission_func_path (str): A dotted string path to a permission function.
+                                        The function should accept two arguments: `user` and `path`,
+                                        and return `True` if the user has permission, or `False` otherwise.
+
+        Returns:
+            function: The decorated view with permission check logic applied.
+
+        Raises:
+            Http404: If the permission function returns `False` or the user lacks the necessary access.
+        """
     def decorator(view_func):
         @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):

--- a/protected_media/decorators.py
+++ b/protected_media/decorators.py
@@ -1,0 +1,21 @@
+from django.http import Http404
+from functools import wraps
+from django.utils.module_loading import import_string
+
+
+def permission_check(permission_func_path):
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped_view(request, *args, **kwargs):
+            path = kwargs.get("path", "")
+            try:
+                permission_func = import_string(permission_func_path)
+            except AttributeError:
+                permission_func = None
+            if permission_func and not permission_func(request.user, path):
+                raise Http404()
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped_view
+
+    return decorator

--- a/protected_media/settings.py
+++ b/protected_media/settings.py
@@ -31,7 +31,10 @@ PROTECTED_MEDIA_SERVER = getattr(
 # Content-Disposition flag will be set.
 PROTECTED_MEDIA_AS_DOWNLOADS = False
 
-# Add business logic with permission check funcion
+# Default permission check function for protected media
+# This setting allows users to define their own business logic for media access permissions.
+# The function should accept two arguments: `user` and `path`, and return `True` if the user has
+# the required access permissions, or `False` otherwise.
 PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION = getattr(
     settings, "PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION", lambda user, path: True
 )

--- a/protected_media/settings.py
+++ b/protected_media/settings.py
@@ -1,11 +1,12 @@
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 if not hasattr(settings, "PROTECTED_MEDIA_ROOT") and not hasattr(settings, "BASE_DIR"):
     raise RuntimeError("The default value for PROTECTED_MEDIA_ROOT requires BASE_DIR to be an available setting.")
 
 # Filesystem location to store protected media.
 PROTECTED_MEDIA_ROOT = getattr(
-    settings, "PROTECTED_MEDIA_ROOT", "%s/protected/" % settings.BASE_DIR 
+    settings, "PROTECTED_MEDIA_ROOT", "%s/protected/" % settings.BASE_DIR
 )
 
 # The URL prefix used by protected media
@@ -30,3 +31,7 @@ PROTECTED_MEDIA_SERVER = getattr(
 # Content-Disposition flag will be set.
 PROTECTED_MEDIA_AS_DOWNLOADS = False
 
+# Add business logic with permission check funcion
+PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION = getattr(
+    settings, "PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION", lambda user, path: True
+)

--- a/protected_media/views.py
+++ b/protected_media/views.py
@@ -13,8 +13,8 @@ from .settings import PROTECTED_MEDIA_LOCATION_PREFIX, PROTECTED_MEDIA_ROOT, PRO
 from .utils import server_header
 
 
-@permission_check(PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION)
 @login_required
+@permission_check(PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION)
 def protected_view(request, path, server="django", as_download=False):
     if server != "django":
         mimetype, encoding = mimetypes.guess_type(path)

--- a/protected_media/views.py
+++ b/protected_media/views.py
@@ -3,16 +3,17 @@ from __future__ import unicode_literals
 
 import mimetypes
 import os
-
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.views.static import serve
 from os.path import basename
 
+from .decorators import permission_check
+from .settings import PROTECTED_MEDIA_LOCATION_PREFIX, PROTECTED_MEDIA_ROOT, PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION
 from .utils import server_header
-from .settings import PROTECTED_MEDIA_LOCATION_PREFIX, PROTECTED_MEDIA_ROOT
 
 
+@permission_check(PROTECTED_MEDIA_CHECK_PERMISSION_FUNCTION)
 @login_required
 def protected_view(request, path, server="django", as_download=False):
     if server != "django":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-protected-media',
-    version='1.0.2',
+    version='1.0.3',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',
@@ -27,6 +27,8 @@ setup(
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
To enforce business-specific rules for accessing protected media, you can define a custom permission function in your settings.py. This function will be dynamically imported and applied using the @permission_check decorator after @login_requred decorator already applied in the view.